### PR TITLE
Spark mvn timeout

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -65,7 +65,7 @@ jobs:
       run: |
         export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=1g -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
         export MAVEN_CLI_OPTS="--no-transfer-progress"
-        echo "<settings><servers><server><id>central</id><configuration><httpConfiguration><all><connectionTimeout>120000</connectionTimeout></all></httpConfiguration></configuration></server></servers></settings>" > ~/.m2/settings.xml
+        echo "<settings><servers><server><id>central</id><configuration><httpConfiguration><all><connectionTimeout>180000</connectionTimeout></all></httpConfiguration></configuration></server></servers></settings>" > ~/.m2/settings.xml
         ./build/mvn $MAVEN_CLI_OPTS -DskipTests -Pyarn -Pmesos -Pkubernetes -Phive -P${{ matrix.hive }} -Phive-thriftserver -P${{ matrix.hadoop }} -Phadoop-cloud -Djava.version=${{ matrix.java }} install
         rm -rf ~/.m2/repository/org/apache/spark
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -64,7 +64,8 @@ jobs:
     - name: Build with Maven
       run: |
         export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=1g -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
-        export MAVEN_CLI_OPTS="--no-transfer-progress -Dmaven.wagon.rto=3600000"
+        export MAVEN_CLI_OPTS="--no-transfer-progress"
+        echo "<settings><servers><server><id>central</id><configuration><httpConfiguration><all><connectionTimeout>120000</connectionTimeout></all></httpConfiguration></configuration></server></servers></settings>" > ~/.m2/settings.xml
         ./build/mvn $MAVEN_CLI_OPTS -DskipTests -Pyarn -Pmesos -Pkubernetes -Phive -P${{ matrix.hive }} -Phive-thriftserver -P${{ matrix.hadoop }} -Phadoop-cloud -Djava.version=${{ matrix.java }} install
         rm -rf ~/.m2/repository/org/apache/spark
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Build with Maven
       run: |
         export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=1g -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
-        export MAVEN_CLI_OPTS="--no-transfer-progress"
+        export MAVEN_CLI_OPTS="--no-transfer-progress -Dmaven.wagon.rto=3600000"
         ./build/mvn $MAVEN_CLI_OPTS -DskipTests -Pyarn -Pmesos -Pkubernetes -Phive -P${{ matrix.hive }} -Phive-thriftserver -P${{ matrix.hadoop }} -Phadoop-cloud -Djava.version=${{ matrix.java }} install
         rm -rf ~/.m2/repository/org/apache/spark
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -65,6 +65,7 @@ jobs:
       run: |
         export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=1g -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
         export MAVEN_CLI_OPTS="-U --no-transfer-progress"
+        echo "<settings><mirrors><mirror><id>google-maven-central</id><name>GCS Maven Central mirror</name><url>https://maven-central.storage-download.googleapis.com/repos/central/data/</url><mirrorOf>central</mirrorOf></mirror></mirrors></settings>" > ~/.m2/settings.xml
         ./build/mvn $MAVEN_CLI_OPTS -DskipTests -Pyarn -Pmesos -Pkubernetes -Phive -P${{ matrix.hive }} -Phive-thriftserver -P${{ matrix.hadoop }} -Phadoop-cloud -Djava.version=${{ matrix.java }} install
         rm -rf ~/.m2/repository/org/apache/spark
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Build with Maven
       run: |
         export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=1g -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
-        export MAVEN_CLI_OPTS="-U --no-transfer-progress"
+        export MAVEN_CLI_OPTS="--no-transfer-progress"
         echo "<settings><mirrors><mirror><id>google-maven-central</id><name>GCS Maven Central mirror</name><url>https://maven-central.storage-download.googleapis.com/repos/central/data/</url><mirrorOf>central</mirrorOf></mirror></mirrors></settings>" > ~/.m2/settings.xml
         ./build/mvn $MAVEN_CLI_OPTS -DskipTests -Pyarn -Pmesos -Pkubernetes -Phive -P${{ matrix.hive }} -Phive-thriftserver -P${{ matrix.hadoop }} -Phadoop-cloud -Djava.version=${{ matrix.java }} install
         rm -rf ~/.m2/repository/org/apache/spark

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -64,8 +64,7 @@ jobs:
     - name: Build with Maven
       run: |
         export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=1g -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
-        export MAVEN_CLI_OPTS="--no-transfer-progress"
-        echo "<settings><servers><server><id>central</id><configuration><httpConfiguration><all><connectionTimeout>180000</connectionTimeout></all></httpConfiguration></configuration></server></servers></settings>" > ~/.m2/settings.xml
+        export MAVEN_CLI_OPTS="-U --no-transfer-progress"
         ./build/mvn $MAVEN_CLI_OPTS -DskipTests -Pyarn -Pmesos -Pkubernetes -Phive -P${{ matrix.hive }} -Phive-thriftserver -P${{ matrix.hadoop }} -Phadoop-cloud -Djava.version=${{ matrix.java }} install
         rm -rf ~/.m2/repository/org/apache/spark
 


### PR DESCRIPTION
`Failed to read artifact descriptor for`.

```
[ERROR] Failed to execute goal on project spark-hive_2.12: Could not resolve dependencies for project org.apache.spark:spark-hive_2.12:jar:3.0.0-SNAPSHOT: Failed to collect dependencies at org.apache.hive:hive-common:jar:2.3.6 -> joda-time:joda-time:jar:2.10.5: Failed to read artifact descriptor for joda-time:joda-time:jar:2.10.5: Could not transfer artifact joda-time:joda-time:pom:2.10.5 from/to central (https://repo.maven.apache.org/maven2): Transfer failed for https://repo.maven.apache.org/maven2/joda-time/joda-time/2.10.5/joda-time-2.10.5.pom: Connection timed out (Read failed) -> [Help 1]
```